### PR TITLE
Include LeapFormatter into single header build, set def width in it

### DIFF
--- a/CLI11.hpp.in
+++ b/CLI11.hpp.in
@@ -66,4 +66,6 @@ namespace {namespace} {{
 
 {formatter_hpp}
 
+{leap_formatter_hpp}
+
 }} // namespace {namespace}

--- a/include/CLI/LeapFormatter.hpp
+++ b/include/CLI/LeapFormatter.hpp
@@ -13,7 +13,6 @@
 // [CLI11:public_includes:end]
 
 #include "App.hpp"
-#include "FormatterFwd.hpp"
 
 namespace CLI {
 // [CLI11:leap_formatter_hpp:verbatim]
@@ -25,7 +24,10 @@ class LeapFormatter : public Formatter {
    const char* tree_fork = u8"\u251C";
 
 public:
-   LeapFormatter() = default;
+   LeapFormatter() : Formatter() {
+      // this gives better, more compact display
+      column_width(25);
+   }
    LeapFormatter(const LeapFormatter&) = default;
    LeapFormatter(LeapFormatter&&) = default;
 


### PR DESCRIPTION
This PR adds new formatter class LeapFormatter into single-header cli11.hpp file that is being build and then included into leap. Also added slightly narrower default column width, as it looks better and common for cleos/leap-util